### PR TITLE
Initialize `nextInChain` to `nil` in extensible getters.

### DIFF
--- a/Sources/generate-webgpu/Generate/GenerateFunction.swift
+++ b/Sources/generate-webgpu/Generate/GenerateFunction.swift
@@ -170,6 +170,12 @@ fileprivate func generateExtensibleGetter(function: FunctionType, isMethod: Bool
             block("return withUnsafeHandle", "_handle in", condition: isMethod) {
                 "var _cStruct = \(structType.cName)()"
                 
+                if let s = structType as? StructureType {
+                    if s.extensible != .none {
+                        "_cStruct.nextInChain = nil"
+                    }
+                }
+                
                 let functionArgs = commaSeparated {
                     if isMethod { "_handle" }
                     "&_cStruct"


### PR DESCRIPTION
Fixes a crash on macOS when calling (some?) extensible getters (e.g. `Adapter.properties`). It seems to work fine on Windows without this patch, maybe Swift runtime does something differently on other platforms, not sure.

Extensible getters create the associated C struct (e.g. `WGPUAdapterProperties`), but it does not reset their `nextInChain` property to `nil`, so Dawn crashes thinking that it's pointing to some real thing.

According to Xcode docs, Swift will zero all values after allocating an imported C struct, but apparently it doesn't always do that.