### PR TITLE
Package dawn artifacts/required files into xcframework for easier integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,7 @@ cython_debug/
 
 # Generated sources
 Sources/WebGpu/Generated
-Sources/DawnNative/Dawn.xcframework/
+Sources/DawnNative/webgpu_dawn.xcframework/
 
 # Dawn-built artifacts we require and their paths
 Sources/DawnNative/lib/libwebgpu_dawn.dylib

--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,7 @@ cython_debug/
 Sources/WebGpu/Generated
 Sources/DawnNative/Dawn.xcframework/
 
-# Dawn-built artifacts we require
+# Dawn-built artifacts we require and their paths
 Sources/DawnNative/lib/libwebgpu_dawn.dylib
 Sources/DawnNative/dawn.json
 Sources/DawnNative/include/

--- a/.gitignore
+++ b/.gitignore
@@ -152,4 +152,7 @@ cython_debug/
 Sources/WebGpu/Generated
 Sources/DawnNative/Dawn.xcframework/
 
-Sources/DawnNative/libwebgpu_dawn.dylib
+# Dawn-built artifacts we require
+Sources/DawnNative/lib/libwebgpu_dawn.dylib
+Sources/DawnNative/dawn.json
+Sources/DawnNative/include/

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ cython_debug/
 
 # Generated sources
 Sources/WebGpu/Generated
+Sources/DawnNative/Dawn.xcframework/
+
+Sources/DawnNative/libwebgpu_dawn.dylib

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["WebGPU"]),
         .library(
             name: "DawnNative",
-            targets: ["DawnNative", "WebGPU"]),
+			targets: ["DawnNative","DawnDylib","WebGPU"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
@@ -60,6 +60,13 @@ let package = Package(
             path: "Demos/WindowUtils"
         ),
         
+		.binaryTarget(
+			name: "DawnDylib",
+			path: "Sources/DawnNative/Dawn.xcframework"
+			//url: "https://github.com/NewChromantics/PopH264/releases/download/v1.3.41/PopH264.xcframework.zip",
+			//checksum: "8a378470a2ab720f2ee6ecf4e7a5e202a3674660c31e43d95d672fe76d61d68c"
+		),
+		
         .executableTarget(
             name: "DemoInfo",
             dependencies: ["DawnNative"],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["WebGPU"]),
         .library(
             name: "DawnNative",
-			targets: ["DawnNative","DawnDylib","WebGPU"]),
+			targets: ["DawnNative","DawnFramework","WebGPU"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
@@ -61,8 +61,8 @@ let package = Package(
         ),
         
 		.binaryTarget(
-			name: "DawnDylib",
-			path: "Sources/DawnNative/Dawn.xcframework"
+			name: "DawnFramework",
+			path: "Sources/DawnNative/webgpu_dawn.xcframework"
 			//url: "https://github.com/NewChromantics/PopH264/releases/download/v1.3.41/PopH264.xcframework.zip",
 			//checksum: "8a378470a2ab720f2ee6ecf4e7a5e202a3674660c31e43d95d672fe76d61d68c"
 		),

--- a/Plugins/GenerateWebGPUPlugin/plugin.swift
+++ b/Plugins/GenerateWebGPUPlugin/plugin.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main struct GenerateWebGPUPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
-        let dawnJsonPath = Path("Sources/DawnNative/dawn.json")
+        let dawnJsonPath = Path("Sources/DawnNative/Dawn.xcframework/dawn.json")
 
         let generateTool = try context.tool(named: "generate-webgpu")
         let outputDir = context.pluginWorkDirectory.appending("Generated")

--- a/Plugins/GenerateWebGPUPlugin/plugin.swift
+++ b/Plugins/GenerateWebGPUPlugin/plugin.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main struct GenerateWebGPUPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
-        let dawnJsonPath = Path("Sources/DawnNative/Dawn.xcframework/dawn.json")
+        let dawnJsonPath = Path("Sources/DawnNative/webgpu_dawn.xcframework/dawn.json")
 
         let generateTool = try context.tool(named: "generate-webgpu")
         let outputDir = context.pluginWorkDirectory.appending("Generated")

--- a/Plugins/GenerateWebGPUPlugin/plugin.swift
+++ b/Plugins/GenerateWebGPUPlugin/plugin.swift
@@ -3,14 +3,8 @@ import Foundation
 
 @main struct GenerateWebGPUPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
-        let dawnJsonPath: Path
-        
-        if let dawnJsonEnv = ProcessInfo.processInfo.environment["DAWN_JSON"] {
-            dawnJsonPath = Path(dawnJsonEnv)
-        } else {
-            dawnJsonPath = Path("/usr/local/share/dawn/dawn.json")
-        }
-        
+        let dawnJsonPath = Path("Sources/DawnNative/dawn.json")
+
         let generateTool = try context.tool(named: "generate-webgpu")
         let outputDir = context.pluginWorkDirectory.appending("Generated")
         

--- a/Sources/DawnNative/CreateXCFramework.sh
+++ b/Sources/DawnNative/CreateXCFramework.sh
@@ -8,7 +8,7 @@ set -e
 #RELEASE_ROOT="Dawn-ecf224df05e711fe7009fbd76840301fb82bde1a-macos-latest-Release"
 RELEASE_ROOT="./"
 
-OUTPUT_FILENAME="Dawn.xcframework"
+OUTPUT_FILENAME="webgpu_dawn.xcframework"
 OUTPUT_PATH="./${OUTPUT_FILENAME}"
 
 MACOS_LIBRARY_PATH="${RELEASE_ROOT}/lib/libwebgpu_dawn.dylib"

--- a/Sources/DawnNative/CreateXCFramework.sh
+++ b/Sources/DawnNative/CreateXCFramework.sh
@@ -11,12 +11,11 @@ RELEASE_ROOT="./"
 OUTPUT_FILENAME="Dawn.xcframework"
 OUTPUT_PATH="./${OUTPUT_FILENAME}"
 
-#MACOS_LIBRARY_PATH="${RELEASE_ROOT}/lib/libwebgpu_dawn.dylib"
-MACOS_LIBRARY_PATH="${RELEASE_ROOT}/libwebgpu_dawn.dylib"
+MACOS_LIBRARY_PATH="${RELEASE_ROOT}/lib/libwebgpu_dawn.dylib"
 MACOS_HEADER_PATH="${RELEASE_ROOT}/include"
 
-#	-headers ${MACOS_HEADER_PATH}	\
 
 xcodebuild -create-xcframework \
 	-library ${MACOS_LIBRARY_PATH} \
+	-headers ${MACOS_HEADER_PATH}	\
 	-output ${OUTPUT_PATH}

--- a/Sources/DawnNative/CreateXCFramework.sh
+++ b/Sources/DawnNative/CreateXCFramework.sh
@@ -1,0 +1,22 @@
+# exit when any command fails
+set -e
+
+# path to the macos artifact from google's CI run
+# https://github.com/google/dawn/actions/workflows/ci.yml
+# expect RELEASE_ROOT/lib and /include dirs inside
+# todo: automate this? or make it a param?
+#RELEASE_ROOT="Dawn-ecf224df05e711fe7009fbd76840301fb82bde1a-macos-latest-Release"
+RELEASE_ROOT="./"
+
+OUTPUT_FILENAME="Dawn.xcframework"
+OUTPUT_PATH="./${OUTPUT_FILENAME}"
+
+#MACOS_LIBRARY_PATH="${RELEASE_ROOT}/lib/libwebgpu_dawn.dylib"
+MACOS_LIBRARY_PATH="${RELEASE_ROOT}/libwebgpu_dawn.dylib"
+MACOS_HEADER_PATH="${RELEASE_ROOT}/include"
+
+#	-headers ${MACOS_HEADER_PATH}	\
+
+xcodebuild -create-xcframework \
+	-library ${MACOS_LIBRARY_PATH} \
+	-output ${OUTPUT_PATH}

--- a/Sources/DawnNative/CreateXCFramework.sh
+++ b/Sources/DawnNative/CreateXCFramework.sh
@@ -15,15 +15,14 @@ MACOS_LIBRARY_PATH="${RELEASE_ROOT}/lib/libwebgpu_dawn.dylib"
 MACOS_HEADER_PATH="${RELEASE_ROOT}/include"
 DAWN_JSON_PATH="${RELEASE_ROOT}/dawn.json"
 
-# we cannot include arbritary files into an xcframework via normal means, but we can sneak them into the headers
-#cp ${DAWN_JSON_PATH} ${MACOS_HEADER_PATH}
-
-rm -r ${OUTPUT_PATH}
+# xcodebuild fails if any contents inside already exist, so clean it out
+# ||true will continue (not exit 1) if the path doesnt exist
+rm -r ${OUTPUT_PATH} || true
 
 xcodebuild -create-xcframework \
 	-library ${MACOS_LIBRARY_PATH} \
 	-headers ${MACOS_HEADER_PATH}	\
 	-output ${OUTPUT_PATH}
 
-# we cannot include arbritary files into an xcframework via normal means, but we can sneak them into the headers
+# we cannot include arbritary files into an xcframework via normal means, but we can sneak them into the output folder
 cp ${DAWN_JSON_PATH} ${OUTPUT_PATH}

--- a/Sources/DawnNative/CreateXCFramework.sh
+++ b/Sources/DawnNative/CreateXCFramework.sh
@@ -13,9 +13,17 @@ OUTPUT_PATH="./${OUTPUT_FILENAME}"
 
 MACOS_LIBRARY_PATH="${RELEASE_ROOT}/lib/libwebgpu_dawn.dylib"
 MACOS_HEADER_PATH="${RELEASE_ROOT}/include"
+DAWN_JSON_PATH="${RELEASE_ROOT}/dawn.json"
 
+# we cannot include arbritary files into an xcframework via normal means, but we can sneak them into the headers
+#cp ${DAWN_JSON_PATH} ${MACOS_HEADER_PATH}
+
+rm -r ${OUTPUT_PATH}
 
 xcodebuild -create-xcframework \
 	-library ${MACOS_LIBRARY_PATH} \
 	-headers ${MACOS_HEADER_PATH}	\
 	-output ${OUTPUT_PATH}
+
+# we cannot include arbritary files into an xcframework via normal means, but we can sneak them into the headers
+cp ${DAWN_JSON_PATH} ${OUTPUT_PATH}


### PR DESCRIPTION
- https://github.com/henrybetts/swift-webgpu/issues/12

Improvement
-------------
These changes to the package setup mean the `dylib`, dawn headers, and `dawn.json` are all bundled into an `.xcframework` which SPM consumes quite nicely.
- Now we don't need any files added to the sytem in `/usr/local` etc
- This can later move so the `xcframework` can come from an URL (ie. github workflow -> release, and automate creation from dawn's own code)
- This now automatically includes the `dylib` into any product of a project that requires it (currently the setup fails as the `dylib` isn't bundled with any projects)

User Instructions
-----------------
- Build dawn as before, but copy
  - `libwebgpu_dawn.dylib`
  - dawn's `include/`
  - dawn's `dawn.json`
- Into `Sources/DawnNative/` and then run `cd Soruces/DawnNaive && ./CreateXCFramework.sh`
- This will generate a `Sources/DawnNative/webgpu_dawn.xcframework`
- The Swift package then gets all it's dependencies from the xcframework when building